### PR TITLE
add option 'rm'

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,21 +18,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-
-    - run: echo "Build some tool and generate some artifacts" > artifact.txt
+      
+    - run: echo "Build some tool and generate some (versioned) artifacts" > artifact-$(date -u +"%Y-%m-%dT%H:%M:%SZ").txt
 
     - name: Single
       uses: ./
       with:
+        rm: true
         token: ${{ secrets.GITHUB_TOKEN }}
-        files: artifact.txt
+        files: artifact-*.txt
 
     - name: List
       uses: ./
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         files: |
-          artifact.txt
+          artifact-*.txt
           README.md
 
     - run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       
-    - run: echo "Build some tool and generate some (versioned) artifacts" > artifact-$(date -u +"%Y-%m-%dT%H:%M:%SZ").txt
+    - run: echo "Build some tool and generate some (versioned) artifacts" > artifact-$(date -u +"%Y-%m-%dT%H-%M-%SZ").txt
 
     - name: Single
       uses: ./

--- a/README.md
+++ b/README.md
@@ -36,3 +36,6 @@ jobs:
 Note that the tag and the pre-release need to be created manually the first time. The workflow above will fail if the release does not exist.
 
 The default tag name is `tip`, but it can be optionally overriden through option `tag` or setting envvar `INPUT_TAG`.
+
+**ADDED**:
+If you systematically want to remove previous artifacts (e.g. old versions), set the `rm` option to true.

--- a/README.md
+++ b/README.md
@@ -37,5 +37,4 @@ Note that the tag and the pre-release need to be created manually the first time
 
 The default tag name is `tip`, but it can be optionally overriden through option `tag` or setting envvar `INPUT_TAG`.
 
-**ADDED**:
 If you systematically want to remove previous artifacts (e.g. old versions), set the `rm` option to true.

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: 'Name of the tag that corresponds to the tip/nightly pre-release'
     required: false
     default: tip
+  remove_all:
+    description: 'Whether to delete all the previous artifacts, or only replacing the ones with the same name'
+    required: false
+    default: false
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: 'Name of the tag that corresponds to the tip/nightly pre-release'
     required: false
     default: tip
-  remove_all:
+  rm:
     description: 'Whether to delete all the previous artifacts, or only replacing the ones with the same name'
     required: false
     default: false

--- a/tip.py
+++ b/tip.py
@@ -77,18 +77,15 @@ else:
     for asset in gh_release.get_assets():
         print(">", asset)
         print(" ", asset.name)
-        if remove_all:
-            asset.delete_asset()
-        else:
-            for artifact in artifacts:
-                aname = str(Path(artifact).name)
-                if asset.name == aname:
-                    print(" removing '%s'..." % asset.name)
-                    asset.delete_asset()
-                    print(" uploading '%s'..." % artifact)
-                    gh_release.upload_asset(artifact, name=aname)
-                    artifacts.remove(artifact)
-                    break
+        for artifact in artifacts:
+            aname = str(Path(artifact).name)
+            if asset.name == aname:
+                print(" removing '%s'..." % asset.name)
+                asset.delete_asset()
+                print(" uploading '%s'..." % artifact)
+                gh_release.upload_asset(artifact, name=aname)
+                artifacts.remove(artifact)
+                break
 
 for artifact in artifacts:
     print(" uploading '%s'..." % artifact)

--- a/tip.py
+++ b/tip.py
@@ -67,25 +67,28 @@ gh_release = gh_repo.get_release(tag)
 print("· Upload artifacts")
 
 artifacts = files
-remove_all = getenv('INPUT_RM', 'false') == 'true'
-if remove_all:
-    print(". RM set. All previous assets will be cleared.")
 
-for asset in gh_release.get_assets():
-    print(">", asset)
-    print(" ", asset.name)
-    if remove_all:
+if getenv('INPUT_RM', 'false') == 'true':
+    print("· RM set. All previous assets are being cleared...")
+    for asset in gh_release.get_assets():
+        print(" ", asset.name)
         asset.delete_asset()
-    else:
-        for artifact in artifacts:
-            aname = str(Path(artifact).name)
-            if asset.name == aname:
-                print(" removing '%s'..." % asset.name)
-                asset.delete_asset()
-                print(" uploading '%s'..." % artifact)
-                gh_release.upload_asset(artifact, name=aname)
-                artifacts.remove(artifact)
-                break
+else:
+    for asset in gh_release.get_assets():
+        print(">", asset)
+        print(" ", asset.name)
+        if remove_all:
+            asset.delete_asset()
+        else:
+            for artifact in artifacts:
+                aname = str(Path(artifact).name)
+                if asset.name == aname:
+                    print(" removing '%s'..." % asset.name)
+                    asset.delete_asset()
+                    print(" uploading '%s'..." % artifact)
+                    gh_release.upload_asset(artifact, name=aname)
+                    artifacts.remove(artifact)
+                    break
 
 for artifact in artifacts:
     print(" uploading '%s'..." % artifact)

--- a/tip.py
+++ b/tip.py
@@ -67,7 +67,8 @@ gh_release = gh_repo.get_release(tag)
 print("· Upload artifacts")
 
 artifacts = files
-remove_all = getenv('INPUT_REMOVE_ALL', 'false') == 'true'
+remove_all = getenv('INPUT_RM', 'false') == 'true'
+print(". RM ", getenv('INPUT_RM', 'false'), remove_all)
 
 for asset in gh_release.get_assets():
     print(">", asset)

--- a/tip.py
+++ b/tip.py
@@ -68,7 +68,8 @@ print("· Upload artifacts")
 
 artifacts = files
 remove_all = getenv('INPUT_RM', 'false') == 'true'
-print(". RM ", getenv('INPUT_RM', 'false'), remove_all)
+if remove_all:
+    print(". RM set. All previous assets will be cleared.")
 
 for asset in gh_release.get_assets():
     print(">", asset)

--- a/tip.py
+++ b/tip.py
@@ -67,19 +67,23 @@ gh_release = gh_repo.get_release(tag)
 print("· Upload artifacts")
 
 artifacts = files
+remove_all = getenv('INPUT_REMOVE_ALL', 'false') == 'true'
 
 for asset in gh_release.get_assets():
     print(">", asset)
     print(" ", asset.name)
-    for artifact in artifacts:
-        aname = str(Path(artifact).name)
-        if asset.name == aname:
-            print(" removing '%s'..." % asset.name)
-            asset.delete_asset()
-            print(" uploading '%s'..." % artifact)
-            gh_release.upload_asset(artifact, name=aname)
-            artifacts.remove(artifact)
-            break
+    if remove_all:
+        asset.delete_asset()
+    else:
+        for artifact in artifacts:
+            aname = str(Path(artifact).name)
+            if asset.name == aname:
+                print(" removing '%s'..." % asset.name)
+                asset.delete_asset()
+                print(" uploading '%s'..." % artifact)
+                gh_release.upload_asset(artifact, name=aname)
+                artifacts.remove(artifact)
+                break
 
 for artifact in artifacts:
     print(" uploading '%s'..." % artifact)


### PR DESCRIPTION
Add an `rm` option to be able to clear all previous artifacts. With `rm: true`, all the artifacts are systematically deleted, then the new artifacts are uploaded. This is especially useful when your artifacts contain version numbers (`xx-v0.0.1.jar`), or are renamed/deleted for a reason or the other. 