### PR TITLE
docker: revert to Python 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:slim-bullseye
+FROM python:3.9-slim-bullseye
 COPY tip.py /tip.py
 RUN pip install PyGithub --progress-bar off
 ENTRYPOINT ["/tip.py"]


### PR DESCRIPTION
Related to #160. The errors started around the time when Python 3.10 was
released, so go back to 3.9.x to see if that is related.